### PR TITLE
Publish Site to persistent environments

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,4 @@
+template: |
+  ## What’s Changed
+
+  $CHANGES

--- a/.github/workflows/release-drafter.yaml
+++ b/.github/workflows/release-drafter.yaml
@@ -1,0 +1,16 @@
+# .github/workflows/release-drafter.yaml
+name: Release Drafter
+
+on:
+  push:
+    branches:
+      - release
+
+jobs:
+  update_release_draft:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: release-drafter/release-drafter@v5
+        with:
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-drafter.yaml
+++ b/.github/workflows/release-drafter.yaml
@@ -11,6 +11,5 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: release-drafter/release-drafter@v5
-        with:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-merge.yaml
+++ b/.github/workflows/release-merge.yaml
@@ -1,0 +1,40 @@
+# .github/workflows/release-merge.yaml
+name: Release Branch Updated
+
+on:
+  push:
+    branches:
+      - release
+
+jobs:
+  preview:
+    name: Update Dev UI
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Get yarn cache
+        id: yarn-cache
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+
+      - uses: actions/cache@v1
+        with:
+          path: ${{ steps.yarn-cache.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+
+      - run: yarn install
+
+      - run: yarn run build
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_KEY }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET }}
+          aws-region: us-east-2
+
+      - name: Publish to S3
+        run: |
+          ./scripts/aws/manage-dev-bucket.sh "${{ secrets.AWS_DEV_BUCKET }}"

--- a/.github/workflows/release-published.yaml
+++ b/.github/workflows/release-published.yaml
@@ -1,0 +1,36 @@
+# .github/workflows/release-published.yaml
+name: Publish to Prod
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  preview:
+    name: Publish UI Changes
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Get yarn cache
+        id: yarn-cache
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+
+      - uses: actions/cache@v1
+        with:
+          path: ${{ steps.yarn-cache.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+
+      - run: yarn install
+
+      - run: yarn run build
+
+      - name: Publish to Master Branch
+        uses: s0/git-publish-subdir-action@master
+        env:
+          REPO: self
+          BRANCH: master
+          FOLDER: public
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/scripts/aws/manage-dev-bucket.sh
+++ b/scripts/aws/manage-dev-bucket.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+set -ex
+
+BUCKET=$1
+
+die() {
+    echo "$1"
+    exit ${2:-1}
+}
+
+[[ -z ${BUCKET} ]] && die "USAGE: $0 <bucket>"
+
+## Create Bucket if it does not already exist and upload
+
+if aws s3api head-bucket --bucket "$BUCKET" 2>/dev/null; then
+  ./scripts/aws/upload-preview-bucket.sh "$BUCKET"
+else
+  ./scripts/aws/create-preview-bucket.sh "$BUCKET" us-east-2
+  ./scripts/aws/upload-preview-bucket.sh "$BUCKET"
+fi


### PR DESCRIPTION
### Requirements
*   Create `AWS_DEV_BUCKET` secret and put the name of the development S3 bucket. Will be created if it does not already exist. 
*   Create a new `release` branch based off of `master`
*   Set `release` branch as default branch in Settings
*   After first release is published, turn on github pages to serve assets from `master`

### Workflow Changes
Pull Requests should be made to `release`. 
Preview PR sites will still be created.
After a PR is merged to `release` it will update the dev S3 bucket and start drafting a new release
Once a release is published, `master` branch will be updated with static site assets. 